### PR TITLE
update license in package.json to match LICENSE

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "BPXWDYN"
   ],
   "author": "ccw",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "devDependencies": {
     "node-gyp": "^3.8.0"
   },


### PR DESCRIPTION
The LICENSE file contains the Apache-2.0 license, yet package.json
specifies the license as ISC. Assuming the LICENSE file contains the
correct license, fix this mismatch by updating the `license` field in
package.json to match the LICENSE file.